### PR TITLE
create tmpdir again when it has vanished.

### DIFF
--- a/lib/fluent/plugin/out_tdlog.rb
+++ b/lib/fluent/plugin/out_tdlog.rb
@@ -246,7 +246,7 @@ class TreasureDataLogOutput < BufferedOutput
     unique_id = chunk.unique_id
     database, table = chunk.key.split('.',2)
 
-    FileUtils.mkdir_p @tmpdir)
+    FileUtils.mkdir_p @tmpdir
     f = Tempfile.new("tdlog-", @tmpdir)
     w = Zlib::GzipWriter.new(f)
 


### PR DESCRIPTION
The default of [tmpdir](https://github.com/treasure-data/fluent-plugin-td/blob/master/lib/fluent/plugin/out_tdlog.rb#L74) is `/tmp/fluent/tdlog`.
If vanished tmp directory by the sort of `tmpwatch`, it will jump into an endless retry loop.

My pull request adding mkdir_p at write block. like this.
https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/out_file.rb#L88
### the error output of stdout

```
2013-**-** **:**:** +0900: temporarily failed to flush the buffer, next retry will be at 2013-**-** **:**:** +0900. error="No such file or directory - /tmp/fluent/tdlog/tdlog-***.lock" instance=***
  2013-**-** **:**:** +0900: /usr/lib64/fluent/ruby/lib/ruby/1.9.1/tempfile.rb:346:in `rmdir'
  2013-**-** **:**:** +0900: /usr/lib64/fluent/ruby/lib/ruby/1.9.1/tempfile.rb:346:in `rmdir'
  2013-**-** **:**:** +0900: /usr/lib64/fluent/ruby/lib/ruby/1.9.1/tempfile.rb:338:in `ensure in locking'
  2013-**-** **:**:** +0900: /usr/lib64/fluent/ruby/lib/ruby/1.9.1/tempfile.rb:338:in `locking'
  2013-**-** **:**:** +0900: /usr/lib64/fluent/ruby/lib/ruby/1.9.1/tempfile.rb:144:in `block in initialize'
  2013-**-** **:**:** +0900: /usr/lib64/fluent/ruby/lib/ruby/1.9.1/tmpdir.rb:133:in `create'
  2013-**-** **:**:** +0900: /usr/lib64/fluent/ruby/lib/ruby/1.9.1/tempfile.rb:134:in `initialize'
  2013-**-** **:**:** +0900: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-td-0.10.12/lib/fluent/plugin/out_tdlog.rb:249:in `new'
  2013-**-** **:**:** +0900: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-td-0.10.12/lib/fluent/plugin/out_tdlog.rb:249:in `write'
  2013-**-** **:**:** +0900: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.27/lib/fluent/buffer.rb:279:in `write_chunk'
  2013-**-** **:**:** +0900: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.27/lib/fluent/buffer.rb:263:in `pop'
  2013-**-** **:**:** +0900: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.27/lib/fluent/output.rb:303:in `try_flush'
  2013-**-** **:**:** +0900: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.27/lib/fluent/output.rb:120:in `run'
```
