### PR TITLE
Better 'cause' logging in rescue block

### DIFF
--- a/lib/fluent/plugin/out_tdlog.rb
+++ b/lib/fluent/plugin/out_tdlog.rb
@@ -303,7 +303,7 @@ module Fluent
         end
       rescue => e
         elapsed = Time.now - start
-        ne = RuntimeError.new("Failed to upload to Treasure Data '#{database}.#{table}' table: #{$!} (#{size} bytes; #{elapsed} seconds)")
+        ne = RuntimeError.new("Failed to upload to Treasure Data '#{database}.#{table}' table: #{e.inspect} (#{size} bytes; #{elapsed} seconds)")
         ne.set_backtrace(e.backtrace)
         raise ne
       end
@@ -320,7 +320,7 @@ module Fluent
         rescue TreasureData::NotFoundError
           raise "Table #{key.inspect} does not exist on Treasure Data. Use 'td table:create #{database} #{table}' to create it."
         rescue => e
-          log.warn "failed to check existence of '#{database}.#{table}' table on Treasure Data", :error => e.to_s
+          log.warn "failed to check existence of '#{database}.#{table}' table on Treasure Data", :error => e.inspect
           log.debug_backtrace e.backtrace
         end
       end

--- a/lib/fluent/plugin/td_plugin_util.rb
+++ b/lib/fluent/plugin/td_plugin_util.rb
@@ -53,7 +53,7 @@ module Fluent
           args = self.class == TreasureDataItemOutput ? ' -t item' : ''
           raise "Table #{key.inspect} does not exist on Treasure Data. Use 'td table:create #{database} #{table}#{args}' to create it."
         rescue => e
-          log.warn "failed to check table existence on Treasure Data", :error => e.to_s
+          log.warn "failed to check table existence on Treasure Data", :error => e.inspect
           log.debug_backtrace e
         end
       end


### PR DESCRIPTION
Log the source error with Error#inspect. Better than Error#to_s because it keeps class name like this;

```
"foo" => "#<RuntimeError: foo>"
```
