### PR TITLE
Change log level and message when a broken record is skipped to make it clear that it is skipped

### DIFF
--- a/lib/fluent/plugin/out_tdlog.rb
+++ b/lib/fluent/plugin/out_tdlog.rb
@@ -232,8 +232,8 @@ module Fluent
           # TODO (a) Remove the transaction mechanism of fluentd
           #      or (b) keep transaction boundaries in in/out_forward.
           #      This code disables the transaction mechanism (a).
-          log.error "#{e}: #{summarize_record(record)}"
-          log.error_backtrace e.backtrace
+          log.warn "Skipped a broken record (#{e}): #{summarize_record(record)}"
+          log.warn_backtrace e.backtrace
           next
         end
 

--- a/test/plugin/test_out_tdlog.rb
+++ b/test/plugin/test_out_tdlog.rb
@@ -99,7 +99,7 @@ class TreasureDataLogOutputTest < Test::Unit::TestCase
 
     assert_equal 0, d.emits.size
     assert d.instance.log.logs.select{ |line|
-      line =~ / \[error\]: Too many number of keys/
+      line =~ /Too many number of keys/
     }.size == 1, "too many keys error is not logged"
   end
 


### PR DESCRIPTION
out_tdlog shows message using "error" level when a record is skipped without saying the record is skipped.
It causes some confuse that users think it's a fatal error where it stopped sending any records to TD.

This fix changes the level to warning and adds "Skipped a broken record" message.