### PR TITLE
Improve tempfile handling in write

### DIFF
--- a/lib/fluent/plugin/out_tdlog.rb
+++ b/lib/fluent/plugin/out_tdlog.rb
@@ -245,7 +245,7 @@ module Fluent
       database, table = chunk.key.split('.', 2)
 
       FileUtils.mkdir_p(@tmpdir) unless @tmpdir.nil?
-      f = Tempfile.new("tdlog-", @tmpdir)
+      f = Tempfile.new("tdlog-#{chunk.key}-", @tmpdir)
       w = Zlib::GzipWriter.new(f)
 
       chunk.write_to(w)
@@ -258,7 +258,7 @@ module Fluent
 
     ensure
       w.close if w
-      f.close if f
+      f.close(true) if f
     end
 
     def upload(database, table, io, size, unique_id)


### PR DESCRIPTION
- Add chunk.key to tempfile name to identify files
- Use close(true) to unlink files immediately