### PR TITLE
Fix Bigint handling to prevent broken msgpack stream

### DIFF
--- a/lib/fluent/plugin/out_tdlog.rb
+++ b/lib/fluent/plugin/out_tdlog.rb
@@ -216,6 +216,8 @@ module Fluent
         begin
           record.to_msgpack(out)
         rescue RangeError
+          # In msgpack v0.5, 'out' becomes String, not Buffer. This is not a problem because Buffer has a compatibility with String
+          out = out.to_s[0, off]
           TreasureData::API.normalized_msgpack(record, out)
         end
 


### PR DESCRIPTION
In msgpack v0.4, to_msgpack appends halfway result into buffer when
serialization failed.

Here is check script:

```rb
#gem 'msgpack', '0.5.11'
gem 'msgpack', '0.4.7'
require 'msgpack'

p MessagePack::VERSION

out = ''.force_encoding('ASCII-8BIT')
off = out.size
[{'k' => 'v'}, {'t' => 100000000000000000000000000000}, {'k' => 'v'}].each { |r|
  begin
    r.to_msgpack(out)
  rescue RangeError => e
    #out = out[0, off] unless defined? MessagePack::Buffer
    r['t'] = r['t'].to_s
    r.to_msgpack(out)
  end

  noff = out.size
  off = noff
}

MessagePack::Unpacker.new.feed_each(out.to_s) { |r|
  p r
}
/Users
```

Result:

### v0.5

```
"0.5.11"
{"k"=>"v"}
{"t"=>"100000000000000000000000000000"}
{"k"=>"v"}
```

### 0.4

```
"0.4.7"
{"k"=>"v"}
{"t"=>{"t"=>"100000000000000000000000000000"}}
{"k"=>"v"}
```

### 0.4 with fix

```
"0.4.7"
{"k"=>"v"}
{"t"=>"100000000000000000000000000000"}
{"k"=>"v"}
```