### PR TITLE
Convert event time to integer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
  - 2.1
  - 2.2.4
  - 2.3.1
+ - 2.4.0
  - ruby-head
 
 gemfile:
@@ -17,6 +18,7 @@ sudo: false
 
 matrix:
   allow_failures:
+    - rvm: 2.4.0
     - rvm: ruby-head
   exclude:
     - rvm: 1.9.3

--- a/lib/fluent/plugin/out_tdlog.rb
+++ b/lib/fluent/plugin/out_tdlog.rb
@@ -126,7 +126,7 @@ module Fluent
         next unless record.is_a?(Hash)
 
         begin
-          record['time'] = time
+          record['time'] = time.to_i
           record.delete(:time) if record.has_key?(:time)
 
           if record.size > @key_num_limit

--- a/test/plugin/test_out_tdlog.rb
+++ b/test/plugin/test_out_tdlog.rb
@@ -117,6 +117,25 @@ class TreasureDataLogOutputTest < Test::Unit::TestCase
     d.run
   end
 
+  def test_emit_with_event_time
+    omit "EventTime is not implemented with current Fluentd version" unless Fluent.const_defined?('EventTime')
+
+    event_time_klass = Fluent.const_get('EventTime')
+
+    event_time = event_time_klass.now
+    d = create_driver
+    _time, records = stub_seed_values
+    database, table = d.instance.instance_variable_get(:@key).split(".", 2)
+    stub_td_table_create_request(database, table)
+    stub_td_import_request(stub_request_body(records, event_time.to_i), database, table)
+
+    _test_time, test_records = stub_seed_values
+    test_records.each { |record|
+      d.emit(record, event_time)
+    }
+    d.run
+  end
+
   def test_emit_with_time_symbole
     d = create_driver
     time, records = stub_seed_values


### PR DESCRIPTION
Treasure Data supports only integer values as time. But this plugin doesn't verify/convert time, but just pack it into msgpack.
Currently `Fluent::EventTime#to_msgpack` overrides default packer behavior to pack event time into integer. So it currently works well. But it will be changed eventually (and this plugin will be broken at that time).

This change is to fix that problem, and runs tests also on Ruby 2.4 (for td-agent3).
Currently there is a bug to convert all integer values into string when any field has a value larger than max int64 value.
I created a fix for that problem here: https://github.com/treasure-data/td-client-ruby/pull/108