### PR TITLE
update td-client dependency to fit for td-agent3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ sudo: false
 
 matrix:
   allow_failures:
-    - rvm: 2.4.0
     - rvm: ruby-head
   exclude:
     - rvm: 2.0

--- a/fluent-plugin-td.gemspec
+++ b/fluent-plugin-td.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
 
   gem.add_dependency "fluentd", [">= 0.10.27", "< 2"]
-  gem.add_dependency "td-client", "~> 0.8.66"
+  gem.add_dependency "td-client", "~> 1.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "webmock", "~> 1.16"
   gem.add_development_dependency "test-unit", "~> 3.0.8"


### PR DESCRIPTION
`td-client-ruby` version 1.0 has been released.
