### PR TITLE
Support Two Endpoints for Import and Operate Separately

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -54,12 +54,19 @@ The configuration options currently supported are:
   This parameter is *required* unless the +auto_create_table+ option is used.
   
 +endpoint+::
-  Specifies the Treasure Data's REST API endpoint.
+  Specifies the Treasure Data's REST API endpoint for import requests.
   
   Requires the endpoint as argument.
   
-  If not specified, a default is used; please refer to the {td-client-ruby's :endpoint}[https://github.com/treasure-data/td-client-ruby#endpoint] option for more details.
+  If not specified, a default for import requests is used; please refer to the {td-client-ruby's :endpoint}[https://github.com/treasure-data/td-client-ruby#endpoint] option for more details.
   
++api_endpoint+::
+  Specifies the Treasure Data's REST API endpoint.
+
+  Requires the endpoint as argument.
+
+  If not specified, a default is used; please refer to the {td-client-ruby's :endpoint}[https://github.com/treasure-data/td-client-ruby#endpoint] option for more details.
+
 +use_ssl+::
   Specifies whether to communicate using SSL encryption over HTTPS.
   

--- a/fluent-plugin-td.gemspec
+++ b/fluent-plugin-td.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |gem|
   gem.version     = Fluent::Plugin::TreasureDataPlugin::VERSION
   gem.authors     = ["Treasure Data, Inc."]
   gem.email       = "support@treasure-data.com"
-  gem.has_rdoc    = false
   #gem.platform    = Gem::Platform::RUBY
   gem.files       = `git ls-files`.split("\n")
   gem.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/fluent/plugin/out_tdlog.rb
+++ b/lib/fluent/plugin/out_tdlog.rb
@@ -22,7 +22,8 @@ module Fluent::Plugin
     config_param :table, :string, :default => nil
     config_param :use_gzip_command, :bool, :default => false
 
-    config_param :endpoint, :string, :default => TreasureData::API::DEFAULT_IMPORT_ENDPOINT
+    config_param :import_endpoint, :string, :alias => :endpoint, :default => TreasureData::API::DEFAULT_IMPORT_ENDPOINT
+    config_param :api_endpoint, :string, :default => TreasureData::API::DEFAULT_ENDPOINT
     config_param :use_ssl, :bool, :default => true
     config_param :tmpdir, :string, :default => nil
     config_param :http_proxy, :string, :default => nil
@@ -78,11 +79,11 @@ module Fluent::Plugin
       super
 
       client_opts = {
-        :ssl => @use_ssl, :http_proxy => @http_proxy, :user_agent => @user_agent, :endpoint => @endpoint,
+        :ssl => @use_ssl, :http_proxy => @http_proxy, :user_agent => @user_agent,
         :connect_timeout => @connect_timeout, :read_timeout => @read_timeout, :send_timeout => @send_timeout
       }
-      @client = TreasureData::Client.new(@apikey, client_opts)
-
+      @client = TreasureData::Client.new(@apikey, client_opts.merge({:endpoint => @import_endpoint}))
+      @api_client = TreasureData::Client.new(@apikey, client_opts.merge({:endpoint => @api_endpoint}))
       if @key
         if @auto_create_table
           ensure_database_and_table(@database, @table)
@@ -263,10 +264,10 @@ module Fluent::Plugin
     def ensure_database_and_table(database, table)
       log.info "Creating table #{database}.#{table} on TreasureData"
       begin
-        @client.create_log_table(database, table)
+        @api_client.create_log_table(database, table)
       rescue TreasureData::NotFoundError
-        @client.create_database(database)
-        @client.create_log_table(database, table)
+        @api_client.create_database(database)
+        @api_client.create_log_table(database, table)
       rescue TreasureData::AlreadyExistsError
       end
     end

--- a/lib/fluent/plugin/out_tdlog.rb
+++ b/lib/fluent/plugin/out_tdlog.rb
@@ -22,7 +22,7 @@ module Fluent::Plugin
     config_param :table, :string, :default => nil
     config_param :use_gzip_command, :bool, :default => false
 
-    config_param :endpoint, :string, :default => TreasureData::API::NEW_DEFAULT_ENDPOINT
+    config_param :endpoint, :string, :default => TreasureData::API::DEFAULT_IMPORT_ENDPOINT
     config_param :use_ssl, :bool, :default => true
     config_param :tmpdir, :string, :default => nil
     config_param :http_proxy, :string, :default => nil

--- a/test/plugin/test_out_tdlog.rb
+++ b/test/plugin/test_out_tdlog.rb
@@ -162,12 +162,11 @@ class TreasureDataLogOutputTest < Test::Unit::TestCase
   end
 
   def test_emit_with_endpoint
-    d = create_driver(DEFAULT_CONFIG + "endpoint foo.bar.baz")
-    opts = {:endpoint => 'foo.bar.baz'}
+    d = create_driver(DEFAULT_CONFIG + "endpoint foo.bar.baz\napi_endpoint boo.bar.baz")
     time, records = stub_seed_values
     database, table = d.instance.instance_variable_get(:@key).split(".", 2)
-    stub_td_table_create_request(database, table, opts)
-    stub_td_import_request(stub_request_body(records, time), database, table, opts)
+    stub_td_table_create_request(database, table, {:endpoint => 'boo.bar.baz'})
+    stub_td_import_request(stub_request_body(records, time), database, table, {:endpoint => 'foo.bar.baz'})
 
     d.run(default_tag: 'test') {
       records.each { |record|

--- a/test/plugin/test_out_tdlog.rb
+++ b/test/plugin/test_out_tdlog.rb
@@ -177,12 +177,11 @@ class TreasureDataLogOutputTest < Test::Unit::TestCase
   end
 
   def test_emit_with_too_many_keys
-    d = create_driver(DEFAULT_CONFIG + "endpoint foo.bar.baz")
-    opts = {:endpoint => 'foo.bar.baz'}
-    time, records = stub_seed_values
+    d = create_driver(DEFAULT_CONFIG)
+    time, _ = stub_seed_values
     database, table = d.instance.instance_variable_get(:@key).split(".", 2)
-    stub_td_table_create_request(database, table, opts)
-    stub_td_import_request(stub_request_body([], time), database, table, opts)
+    stub_td_table_create_request(database, table)
+    stub_td_import_request(stub_request_body([], time), database, table)
 
     d.run(default_tag: 'test') {
       d.feed(time, create_too_many_keys_record)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -59,7 +59,7 @@ class Test::Unit::TestCase
     opts[:use_ssl] = true unless opts.has_key?(:use_ssl)
     schema = opts[:use_ssl] ? 'https' : 'http'
     response = {"database" => database, "table" => table}.to_json
-    endpoint = opts[:endpoint] ? opts[:endpoint] : TreasureData::API::NEW_DEFAULT_ENDPOINT
+    endpoint = opts[:endpoint] ? opts[:endpoint] : TreasureData::API::DEFAULT_ENDPOINT
 
     url = "#{schema}://#{endpoint}/v3/table/create/#{e(database)}/#{e(table)}/log"
     stub_request(:post, url).to_return(:status => 200, :body => response)
@@ -70,7 +70,7 @@ class Test::Unit::TestCase
     format = opts[:format] || 'msgpack.gz'
     schema = opts[:use_ssl] ? 'https' : 'http'
     response = {"database" => db, "table" => table, "elapsed_time" => 0}.to_json
-    endpoint = opts[:endpoint] ? opts[:endpoint] : TreasureData::API::NEW_DEFAULT_IMPORT_ENDPOINT
+    endpoint = opts[:endpoint] ? opts[:endpoint] : TreasureData::API::DEFAULT_IMPORT_ENDPOINT
 
     # for check_table_existence
     url_with_empty = "#{schema}://#{endpoint}/v3/table/import/#{e(db)}/#{e(table)}/#{format}"


### PR DESCRIPTION
Now Treasure Data has two different endpoints that relates import requests. One is the general API endpoint, the other is the API endpoint only for import requests.
(For example, `api.treasuredata.com` and `api-import.treasuredata.com` in site:aws for now)

Those endpoints can route requests which are not hosted by themselves to each other. But if clients can send requests to appropriate endpoints directly, it can reduce RTTs and also can reduce the number of troubles caused by the complex request routing.

This change doesn't break compatibilities because existing endpoints can route requests to each other as I wrote above, and it'll continue in future.