### PR TITLE
Prevent retrying unretriable errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source "http://rubygems.org"
 
-gem "td-client", git: "https://github.com/treasure-data/td-client-ruby.git"
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "http://rubygems.org"
 
+gem "td-client", git: "https://github.com/treasure-data/td-client-ruby.git"
 gemspec

--- a/fluent-plugin-td.gemspec
+++ b/fluent-plugin-td.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
 
   gem.add_dependency "fluentd", [">= 0.14.13", "< 2"]
+  gem.add_dependency "td-client"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "webmock", "~> 1.16"
   gem.add_development_dependency "test-unit", "~> 3.0.8"

--- a/fluent-plugin-td.gemspec
+++ b/fluent-plugin-td.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
 
   gem.add_dependency "fluentd", [">= 0.14.13", "< 2"]
-  gem.add_dependency "td-client", "~> 1.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "webmock", "~> 1.16"
   gem.add_development_dependency "test-unit", "~> 3.0.8"

--- a/fluent-plugin-td.gemspec
+++ b/fluent-plugin-td.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
 
   gem.add_dependency "fluentd", [">= 0.14.13", "< 2"]
-  gem.add_dependency "td-client"
+  gem.add_dependency "td-client", "~> 1.0.8"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "webmock", "~> 1.16"
   gem.add_development_dependency "test-unit", "~> 3.0.8"

--- a/fluent-plugin-td.gemspec
+++ b/fluent-plugin-td.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
 
   gem.add_dependency "fluentd", [">= 0.14.13", "< 2"]
-  gem.add_dependency "td-client", "~> 1.0.8"
+  gem.add_dependency "td-client", ">= 1.0.8"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "webmock", "~> 1.16"
   gem.add_development_dependency "test-unit", "~> 3.0.8"

--- a/lib/fluent/plugin/out_tdlog.rb
+++ b/lib/fluent/plugin/out_tdlog.rb
@@ -4,6 +4,7 @@ require 'zlib'
 require 'stringio'
 require 'td-client'
 
+require 'fluent/error'
 require 'fluent/plugin/output'
 require 'fluent/plugin/td_plugin_version'
 
@@ -215,14 +216,20 @@ module Fluent::Plugin
         begin
           start = Time.now
           @client.import(database, table, UPLOAD_EXT, io, size, unique_str)
-        rescue TreasureData::NotFoundError => e
+        rescue TreasureData::NotFoundError
           unless @auto_create_table
-            raise e
+            raise
           end
           ensure_database_and_table(database, table)
           io.pos = 0
           retry
+        rescue TreasureData::ClientError
+          raise
         end
+      rescue TreasureData::TooManyRequestsError
+        raise
+      rescue TreasureData::ClientError => e
+        raise Fluent::UnrecoverableError.new(e.message)
       rescue => e
         elapsed = Time.now - start
         ne = RuntimeError.new("Failed to upload to Treasure Data '#{database}.#{table}' table: #{e.inspect} (#{size} bytes; #{elapsed} seconds)")

--- a/lib/fluent/plugin/out_tdlog.rb
+++ b/lib/fluent/plugin/out_tdlog.rb
@@ -223,8 +223,6 @@ module Fluent::Plugin
           ensure_database_and_table(database, table)
           io.pos = 0
           retry
-        rescue TreasureData::ClientError
-          raise
         end
       rescue TreasureData::TooManyRequestsError
         raise

--- a/lib/fluent/plugin/td_plugin_version.rb
+++ b/lib/fluent/plugin/td_plugin_version.rb
@@ -1,7 +1,7 @@
 module Fluent
   module Plugin
     module TreasureDataPlugin
-      VERSION = '1.1.0'
+      VERSION = '1.2.0'
     end
   end
 end

--- a/test/plugin/test_out_tdlog.rb
+++ b/test/plugin/test_out_tdlog.rb
@@ -144,7 +144,7 @@ class TreasureDataLogOutputTest < Test::Unit::TestCase
     }
   end
 
-  def test_emit_with_time_symbole
+  def test_emit_with_time_symbol
     d = create_driver
     time, records = stub_seed_values
     database, table = d.instance.instance_variable_get(:@key).split(".", 2)
@@ -190,6 +190,38 @@ class TreasureDataLogOutputTest < Test::Unit::TestCase
     assert_equal 1, d.error_events.size
   end
 
+  def test_write_with_client_error
+    d = create_driver(DEFAULT_CONFIG)
+    time, records = stub_seed_values
+    database, table = d.instance.instance_variable_get(:@key).split(".", 2)
+    stub_td_table_create_request(database, table)
+    stub_td_import_request(stub_request_body(records, time), database, table, status: 400)
+
+    assert_nothing_raised(Fluent::UnrecoverableError) do
+      d.run(default_tag: 'test') {
+        records.each { |record|
+          d.feed(time, record)
+        }
+      }
+    end
+  end
+
+  def test_write_retry_if_too_many_requests
+    d = create_driver(DEFAULT_CONFIG)
+    time, records = stub_seed_values
+    database, table = d.instance.instance_variable_get(:@key).split(".", 2)
+    stub_td_table_create_request(database, table)
+    stub_td_import_request(stub_request_body(records, time), database, table, status: 429)
+
+    assert_raise(TreasureData::TooManyRequestsError) do
+      d.run(default_tag: 'test') {
+        records.each { |record|
+          d.feed(time, record)
+        }
+      }
+    end
+  end
+
   sub_test_case 'tag splitting for database and table' do
     def create_driver(conf = %[auto_create_table true])
       config = BASE_CONFIG + conf
@@ -197,7 +229,7 @@ class TreasureDataLogOutputTest < Test::Unit::TestCase
       Fluent::Test::Driver::Output.new(Fluent::Plugin::TreasureDataLogOutput).configure(config)
     end
 
-    data('evet_time' => 'event_time', 'int_time' => 'int')
+    data('event_time' => 'event_time', 'int_time' => 'int')
     def test_tag_split(time_class)
       d = create_driver
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -69,6 +69,7 @@ class Test::Unit::TestCase
     opts[:use_ssl] = true unless opts.has_key?(:use_ssl)
     format = opts[:format] || 'msgpack.gz'
     schema = opts[:use_ssl] ? 'https' : 'http'
+    status = opts[:status] || 200
     response = {"database" => db, "table" => table, "elapsed_time" => 0}.to_json
     endpoint = opts[:endpoint] ? opts[:endpoint] : TreasureData::API::DEFAULT_IMPORT_ENDPOINT
 
@@ -80,6 +81,6 @@ class Test::Unit::TestCase
     stub_request(:put, url_with_unique).with(:headers => {'Content-Type' => 'application/octet-stream'}) { |req|
       @auth_header = req.headers["Authorization"]
       stub_gzip_unwrap(req.body) == stub_gzip_unwrap(body)
-    }.to_return(:status => 200, :body => response)
+    }.to_return(:status => status, :body => response)
   end
 end


### PR DESCRIPTION
Today the plugin will retry any non 200 responses, which make sense for most errors, except client errors that have no guarantee to be successful on retry (outside of 429).

This change rely on the newly released version of td ruby client hence the gemspec change and the draft PR.
It will essentially give up uploading on a client error but will still retry on 429 response status.