### PR TITLE
use_gzip_command is not available on Windows

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -93,6 +93,8 @@ The configuration options currently supported are:
 
 +use_gzip_command+::
   Use external gzip command instead of Ruby's Gzip library. It uses another CPU core so it may improve compression and IO performance.
+  
+  On Windows, this option is not available and Ruby's Gzip library is used even if you set this option to `true`.
 
 
 == Copyright

--- a/test/plugin/test_out_tdlog.rb
+++ b/test/plugin/test_out_tdlog.rb
@@ -87,6 +87,7 @@ class TreasureDataLogOutputTest < Test::Unit::TestCase
   end
 
   def test_emit_with_gzip_command
+    omit "On Windows, `use_gzip_command` is not available." if Fluent.windows?
     d = create_driver(DEFAULT_CONFIG + "use_gzip_command true")
     time, records = stub_seed_values
     database, table = d.instance.instance_variable_get(:@key).split(".", 2)


### PR DESCRIPTION
`use_gzip_command` is not available on Windows.

The command always fails as follows on Windows, and `gzip_by_writer` is used instead.

```
The process cannot access the file because it is being used by another process.
```

So I think we need to fix README and a test for now.

I confirmed this as follows.

* Use the following environment.
  * Windows 10 Home
  * Ruby 3.2
  * The latest master of this repository (ae23a9182b98d2f8532a61baa4254894e04cfa1c)
* Remove `Gemfile.lock`
  * Somehow `PLATFORMS` specified in this lock file is not suitable for Fluentd on Windows.
  * When I run `$ bundle`, the next warning message occurred, and I can't run the tests.
  ```
  Unable to use the platform-specific (x64-mingw-ucrt) version of fluentd (1.15.3) because it has
  different dependencies from the ruby version. To use the platform-specific version of the gem,
  run `bundle config set specific_platform true` and install again.
  ```
  * Why does this repository manage `Gemfile.lock` file?
* Install the dependencies by `$ bundle`
* Run the tests by `$ bundle exec rake test`

Then the `test_emit_with_gzip_command` test fails as follows.

```
The process cannot access the file because it is being used by another process.
 #<Thread:0x000001d74d2ce9f0@flush_thread_0 C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin_helper/thread.rb:70 run> terminated with exception (report_on_exception is true):
 C:/Users/reang/Documents/work/fluentd/fluentdPlugins/fluent-plugin-td/lib/fluent/plugin/out_tdlog.rb:188:in `gzip_by_command': Called 1 time. (RR::Errors::TimesCalledError)
 Expected 0 times.
         from C:/Users/reang/Documents/work/fluentd/fluentdPlugins/fluent-plugin-td/lib/fluent/plugin/out_tdlog.rb:163:in `write'
         from C:/Users/reang/Documents/work/fluentd/fluentdPlugins/fluent-plugin-td/test/plugin/test_out_tdlog.rb:39:in `write'
         from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin/output.rb:1180:in `try_flush'
         from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin/output.rb:1501:in `flush_thread_run'
         from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin/output.rb:501:in `block (2 levels) in start'
         from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
 E, [2023-03-01T14:51:57.338561 #13908] ERROR -- : unexpected error while after_shutdown, RR::Errors::TimesCalledError:Called 1 time.
 Expected 0 times.
 E, [2023-03-01T14:51:57.339015 #13908] ERROR -- :       C:/Users/reang/Documents/work/fluentd/fluentdPlugins/fluent-plugin-td/lib/fluent/plugin/out_tdlog.rb:188:in `gzip_by_command'
 E, [2023-03-01T14:51:57.339265 #13908] ERROR -- :       C:/Users/reang/Documents/work/fluentd/fluentdPlugins/fluent-plugin-td/lib/fluent/plugin/out_tdlog.rb:163:in `write'
 E, [2023-03-01T14:51:57.339509 #13908] ERROR -- :       C:/Users/reang/Documents/work/fluentd/fluentdPlugins/fluent-plugin-td/test/plugin/test_out_tdlog.rb:39:in `write'
 E, [2023-03-01T14:51:57.339754 #13908] ERROR -- :       C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin/output.rb:1180:in `try_flush'
 E, [2023-03-01T14:51:57.339990 #13908] ERROR -- :       C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin/output.rb:1501:in `flush_thread_run'
 E, [2023-03-01T14:51:57.340234 #13908] ERROR -- :       C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin/output.rb:501:in `block (2 levels) in start'
 E, [2023-03-01T14:51:57.340467 #13908] ERROR -- :       C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
 F
 ==============================================================================================================================================================================================================================================Failure: test_emit_with_gzip_command(TreasureDataLogOutputTest):
   Called 1 time.
   Expected 0 times.
 C:/Users/reang/Documents/work/fluentd/fluentdPlugins/fluent-plugin-td/lib/fluent/plugin/out_tdlog.rb:188:in `gzip_by_command'
 C:/Users/reang/Documents/work/fluentd/fluentdPlugins/fluent-plugin-td/lib/fluent/plugin/out_tdlog.rb:163:in `write'
 C:/Users/reang/Documents/work/fluentd/fluentdPlugins/fluent-plugin-td/test/plugin/test_out_tdlog.rb:39:in `write'
 C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin/output.rb:1180:in `try_flush'
 C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin/output.rb:1501:in `flush_thread_run'
 C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin/output.rb:501:in `block (2 levels) in start'
 C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
```