### PR TITLE
Add CI as GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+on: [push, pull_request]
+jobs:
+  Test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Test
+        run: bundle exec rake test


### PR DESCRIPTION
The next [td-agent](https://github.com/fluent/fluent-package-builder) will embed Ruby 3.2.

I was checking each embedded plugin and noticed that this plugin has no GitHub CI.

How about adding GitHub CI like this?

Or could you please add `Ruby 3.2` to CircleCI tests?

I opened another PR related to this.

* #46 

In both my local environment and this GitHub CI, the tests on Windows don't work.
There are 2 reasons for this.

* `use_gzip_command` option is not available on Windows (this will be fixed by #46)
* `Gemfile.lock` file looks not suitable for Fluentd on Windows.
  * This is also mentioned in #46.
  * `PLATFORMS` may be the cause. It seems that `x64-mingw32` or `x64-mingw32-ucrt` are needed.

I'm wondering how we should resolve the latter issue about `Gemfile.lock` on Windows. 

Many other plugins don't manage the lock file, is there any reason for managing the lock file in this repository?